### PR TITLE
update to openvpn-as 2.1.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
 # package version
-ARG OPENVPN_VER="2.1.9"
+ARG OPENVPN_VER="2.1.12"
 
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The "admin" account is a system (PAM) account and after container update or recr
 
 ## Versions
 
++ **25.10.17:** Pick up version 2.1.12.
 + **18.08.17:** Switch default authentication method to local, update readme on how to deactivate the admin user
 + **31.07.17:** Fix updates of existing openvpn-as installs.
 + **07.07.17:** Pick up version 2.1.9.


### PR DESCRIPTION
This bumps the version to 2.1.12, the latest.  I have tested this in my environment and it seems to work without issue.