### PR TITLE
Allow container to run without --privileged or --net=host

### DIFF
--- a/root/etc/services.d/openvpn/run
+++ b/root/etc/services.d/openvpn/run
@@ -1,3 +1,7 @@
 #!/usr/bin/with-contenv bash
+mkdir -p /dev/net
+if [ ! -c /dev/net/tun ]; then
+  mknod /dev/net/tun c 10 200
+fi
 
 /config/scripts/openvpnas --nodaemon --umask=0077 --pidfile=/openvpn/pid/openvpn.pid --logfile=/config/log/openvpn.log


### PR DESCRIPTION
This change creates /dev/net/tun inside the container so that it can run without --privileged and without --net=host.

For example:
```
docker run -v \
<path to data>:/config \
--cap-add NET_ADMIN \
-p 1194:1194/udp \
-p 943:943 \
linuxserver/openvpn-as
```
It can also run from docker-compose.yml, which I was unable to make work previously:
```
version: '2'
services:
  openvpnas:
    # Build from checkout until new image pushed to docker hub
    build: . 
    ports:
      - "943:943"
      - "1194:1194/udp"
    volumes:
      - <volume path>:/config
    cap_add:
      - NET_ADMIN
```

It's quite likely this logic should move to a more appropriate init script.  I'm happy to change it and update the README, but I figured I'd present this as a working PR as a starting point.

Inspired by init scripts in: https://github.com/kylemanna/docker-openvpn/